### PR TITLE
Add dotenv configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+OLLAMA_BASE_URL=http://localhost:11434
+QDRANT_HOST=localhost
+QDRANT_PORT=6333
+EMBEDDING_MODEL=nomic-embed-text
+LLM_MODEL=llama2

--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@ Run the server:
 ```bash
 uvicorn app.main:app --reload
 ```
-The service uses `OLLAMA_EMBEDDING_URL`, `OLLAMA_GENERATE_URL`, `OLLAMA_MODEL`,
-`OLLAMA_LLM_MODEL`, and `QDRANT_URL` environment variables. Defaults are defined in `app/main.py` and can be
-overridden.
+Create a `.env` file to configure the service:
+```
+OLLAMA_BASE_URL=http://localhost:11434
+QDRANT_HOST=localhost
+QDRANT_PORT=6333
+EMBEDDING_MODEL=nomic-embed-text
+LLM_MODEL=llama2
+```
+These values are loaded via `python-dotenv` and override the defaults defined in
+`app/main.py`.
 
 ## Upload Endpoint
 `POST /api/upload`

--- a/app/main.py
+++ b/app/main.py
@@ -12,20 +12,26 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 import PyPDF2
 import docx
 import requests
+from dotenv import load_dotenv
+import os
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+load_dotenv()
 
 from .services.qdrant_client import QdrantClient
 
 app = FastAPI()
 
-OLLAMA_EMBEDDING_URL = "http://localhost:11434/api/embeddings"
-OLLAMA_GENERATE_URL = "http://localhost:11434/api/generate"
-QDRANT_URL = "http://localhost:6333"
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
+OLLAMA_EMBEDDING_URL = f"{OLLAMA_BASE_URL}/api/embeddings"
+OLLAMA_GENERATE_URL = f"{OLLAMA_BASE_URL}/api/generate"
+QDRANT_HOST = os.getenv("QDRANT_HOST", "localhost")
+QDRANT_PORT = os.getenv("QDRANT_PORT", "6333")
+QDRANT_URL = f"http://{QDRANT_HOST}:{QDRANT_PORT}"
 COLLECTION_NAME = "documents"
-OLLAMA_MODEL = "nomic-embed-text"
-OLLAMA_LLM_MODEL = "llama2"
+OLLAMA_MODEL = os.getenv("EMBEDDING_MODEL", "nomic-embed-text")
+OLLAMA_LLM_MODEL = os.getenv("LLM_MODEL", "llama2")
 
 qdrant_client = QdrantClient(QDRANT_URL, COLLECTION_NAME)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyPDF2
 python-docx
 langchain
 requests
+python-dotenv


### PR DESCRIPTION
## Summary
- support environment variables loaded from `.env`
- document `.env` usage in README
- require python-dotenv

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d8315330083339bb57f930476ca18