### PR TITLE
Add Next.js frontend for document Q&A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,5 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+# Node
+frontend/node_modules/

--- a/frontend/components/QnAForm.tsx
+++ b/frontend/components/QnAForm.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { askQuestion } from '@/utils/api'
+
+interface Answer {
+  answer: string
+  references: string[]
+}
+
+export default function QnAForm() {
+  const [question, setQuestion] = useState('')
+  const [response, setResponse] = useState<Answer | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!question) return
+    setLoading(true)
+    try {
+      const data = await askQuestion(question)
+      setResponse(data)
+    } catch (err) {
+      setResponse({ answer: 'Error fetching answer', references: [] })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <form onSubmit={handleSubmit} className="flex space-x-2">
+        <input
+          type="text"
+          value={question}
+          onChange={e => setQuestion(e.target.value)}
+          className="flex-1 border rounded p-2"
+          placeholder="Ask a question"
+        />
+        <button
+          type="submit"
+          className="px-4 py-2 bg-green-600 text-white rounded"
+          disabled={loading}
+        >
+          {loading ? 'Asking...' : 'Ask'}
+        </button>
+      </form>
+      {response && (
+        <div className="space-y-2 bg-gray-100 p-4 rounded">
+          <p className="font-semibold">Answer:</p>
+          <p>{response.answer}</p>
+          {response.references.length > 0 && (
+            <div>
+              <p className="font-semibold mt-2">References:</p>
+              <ul className="list-disc list-inside space-y-1">
+                {response.references.map((ref, idx) => (
+                  <li key={idx}>{ref}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/UploadForm.tsx
+++ b/frontend/components/UploadForm.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import { uploadFile } from '@/utils/api'
+
+export default function UploadForm() {
+  const [file, setFile] = useState<File | null>(null)
+  const [message, setMessage] = useState('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!file) return
+    try {
+      await uploadFile(file)
+      setMessage('Upload succeeded')
+      setFile(null)
+    } catch (err) {
+      setMessage('Upload failed')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2" encType="multipart/form-data">
+      <input
+        type="file"
+        accept="application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        onChange={e => setFile(e.target.files?.[0] || null)}
+        className="block w-full text-sm"
+      />
+      <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
+        Upload
+      </button>
+      {message && <p className="text-sm text-gray-600">{message}</p>}
+    </form>
+  )
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.5",
+    "@types/react": "18.2.15",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.3",
+    "typescript": "5.2.2"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '@/styles/globals.css'
+import type { AppProps } from 'next/app'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,12 @@
+import UploadForm from '@/components/UploadForm'
+import QnAForm from '@/components/QnAForm'
+
+export default function Home() {
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-8">
+      <h1 className="text-2xl font-bold text-center">Document Q&A</h1>
+      <UploadForm />
+      <QnAForm />
+    </div>
+  )
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"],
+      "@components/*": ["components/*"],
+      "@utils/*": ["utils/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -1,0 +1,27 @@
+export async function uploadFile(file: File) {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const res = await fetch('/api/upload', {
+    method: 'POST',
+    body: formData,
+  });
+  if (!res.ok) {
+    throw new Error('Upload failed');
+  }
+  return res.json();
+}
+
+export async function askQuestion(question: string) {
+  const res = await fetch('/api/ask', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ question }),
+  });
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- create a basic Next.js frontend project
- add upload and question forms
- implement fetch helpers
- configure Tailwind CSS

## Testing
- `npm install` *(fails: 403 Forbidden, registry access blocked)*
- `npm run build` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_685d8499f02c83338c8ad8599c843339