### PR TITLE
Add document listing, summarization and UI history features

### DIFF
--- a/frontend/components/QnAForm.tsx
+++ b/frontend/components/QnAForm.tsx
@@ -6,10 +6,16 @@ interface Answer {
   references: string[]
 }
 
+interface QARecord {
+  question: string
+  answer: string
+}
+
 export default function QnAForm() {
   const [question, setQuestion] = useState('')
   const [response, setResponse] = useState<Answer | null>(null)
   const [loading, setLoading] = useState(false)
+  const [history, setHistory] = useState<QARecord[]>([])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -18,8 +24,11 @@ export default function QnAForm() {
     try {
       const data = await askQuestion(question)
       setResponse(data)
+      setHistory([{ question, answer: data.answer }, ...history])
     } catch (err) {
-      setResponse({ answer: 'Error fetching answer', references: [] })
+      const errRecord = { question, answer: 'Error fetching answer' }
+      setResponse({ answer: errRecord.answer, references: [] })
+      setHistory([errRecord, ...history])
     } finally {
       setLoading(false)
     }
@@ -45,7 +54,16 @@ export default function QnAForm() {
       </form>
       {response && (
         <div className="space-y-2 bg-gray-100 p-4 rounded">
-          <p className="font-semibold">Answer:</p>
+          <div className="flex justify-between">
+            <p className="font-semibold">Answer:</p>
+            <button
+              type="button"
+              onClick={() => navigator.clipboard.writeText(response.answer)}
+              className="text-sm text-blue-600 underline"
+            >
+              複製回答
+            </button>
+          </div>
           <p>{response.answer}</p>
           {response.references.length > 0 && (
             <div>
@@ -57,6 +75,19 @@ export default function QnAForm() {
               </ul>
             </div>
           )}
+        </div>
+      )}
+      {history.length > 0 && (
+        <div className="space-y-2">
+          <p className="font-semibold">回答記錄:</p>
+          <ul className="space-y-1">
+            {history.map((h, idx) => (
+              <li key={idx} className="border p-2 rounded">
+                <p className="text-sm font-semibold">Q: {h.question}</p>
+                <p className="text-sm">A: {h.answer}</p>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
     </div>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,11 +1,64 @@
 import UploadForm from '@/components/UploadForm'
 import QnAForm from '@/components/QnAForm'
+import { useEffect, useState } from 'react'
+import { fetchDocs, fetchDocumentSegments } from '@/utils/api'
+
+interface Doc {
+  document_id: string
+  file_name: string
+  upload_time: string
+}
+
+interface Segment {
+  text: string
+  chunk_index?: number
+}
 
 export default function Home() {
+  const [docs, setDocs] = useState<Doc[]>([])
+  const [segments, setSegments] = useState<Segment[]>([])
+  const [selected, setSelected] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchDocs().then(data => setDocs(data.documents || []))
+  }, [])
+
+  async function handleSelect(id: string) {
+    const data = await fetchDocumentSegments(id)
+    setSelected(id)
+    setSegments(data.segments || [])
+  }
+
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-8">
       <h1 className="text-2xl font-bold text-center">Document Q&A</h1>
       <UploadForm />
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">檔案紀錄</h2>
+        <ul className="list-disc list-inside space-y-1">
+          {docs.map(doc => (
+            <li key={doc.document_id}>
+              <button
+                className="text-blue-600 underline"
+                onClick={() => handleSelect(doc.document_id)}
+              >
+                {doc.document_id} (
+                {new Date(doc.upload_time).toLocaleString()})
+              </button>
+            </li>
+          ))}
+        </ul>
+        {selected && (
+          <div className="space-y-1 mt-2">
+            <h3 className="font-semibold">Segments of {selected}</h3>
+            <ul className="list-decimal list-inside space-y-1">
+              {segments.map((s, idx) => (
+                <li key={idx}>{s.text}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
       <QnAForm />
     </div>
   )

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -25,3 +25,19 @@ export async function askQuestion(question: string) {
   }
   return res.json();
 }
+
+export async function fetchDocs() {
+  const res = await fetch('/api/docs');
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return res.json();
+}
+
+export async function fetchDocumentSegments(id: string) {
+  const res = await fetch(`/api/docs/${id}`);
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add summary creation and document listing endpoints
- implement Qdrant helpers for listing documents and retrieving segments
- enhance QnAForm with copy button and history
- show document records in home page
- expose frontend helpers to call new APIs

## Testing
- `python -m py_compile app/main.py app/services/qdrant_client.py`
- `pytest -q`
- `npm run build` *(fails: `next` not found due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685d86427fac833393a3f5ad67e9b48c