### PR TITLE
Implement document management features

### DIFF
--- a/app/upload.py
+++ b/app/upload.py
@@ -51,6 +51,12 @@ def append_doc_summary(document_id: str, summary: str) -> None:
     index[document_id] = summary
     save_doc_index(index)
 
+def remove_doc_summary(document_id: str) -> None:
+    index = load_doc_index()
+    if document_id in index:
+        index.pop(document_id, None)
+        save_doc_index(index)
+
 def get_embedding(text: str) -> List[float]:
     try:
         resp = requests.post(

--- a/frontend/components/DocContext.tsx
+++ b/frontend/components/DocContext.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, useState } from 'react'
+
+interface DocState {
+  selectedDocId: string | null
+  setSelectedDocId: (id: string | null) => void
+}
+
+const DocContext = createContext<DocState>({
+  selectedDocId: null,
+  setSelectedDocId: () => {},
+})
+
+export function useDoc() {
+  return useContext(DocContext)
+}
+
+export function DocProvider({ children }: { children: React.ReactNode }) {
+  const [selectedDocId, setSelectedDocId] = useState<string | null>(null)
+  return (
+    <DocContext.Provider value={{ selectedDocId, setSelectedDocId }}>
+      {children}
+    </DocContext.Provider>
+  )
+}

--- a/frontend/components/DocumentDetail.tsx
+++ b/frontend/components/DocumentDetail.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import { fetchDocumentSegments } from '@/utils/api'
+
+interface Segment {
+  text: string
+  chunk_index?: number
+}
+
+export default function DocumentDetail({ id }: { id: string }) {
+  const [segments, setSegments] = useState<Segment[]>([])
+
+  useEffect(() => {
+    fetchDocumentSegments(id).then(data => setSegments(data.segments || []))
+  }, [id])
+
+  return (
+    <div className="space-y-1">
+      <h2 className="text-xl font-semibold mb-2">Segments</h2>
+      <ol className="list-decimal list-inside space-y-1">
+        {segments.map((s, idx) => (
+          <li key={idx}>{s.text}</li>
+        ))}
+      </ol>
+    </div>
+  )
+}

--- a/frontend/components/DocumentsList.tsx
+++ b/frontend/components/DocumentsList.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { fetchDocs, deleteDoc } from '@/utils/api'
+import { useDoc } from './DocContext'
+
+interface Doc {
+  document_id: string
+  file_name: string
+  upload_time: string
+  summary?: string
+}
+
+export default function DocumentsList() {
+  const [docs, setDocs] = useState<Doc[]>([])
+  const { selectedDocId, setSelectedDocId } = useDoc()
+
+  useEffect(() => {
+    fetchDocs().then(data => setDocs(data.documents || []))
+  }, [])
+
+  async function handleDelete(id: string) {
+    if (!confirm('Delete document?')) return
+    await deleteDoc(id)
+    setDocs(docs.filter(d => d.document_id !== id))
+    if (selectedDocId === id) {
+      setSelectedDocId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-xl font-semibold">檔案紀錄</h2>
+      <ul className="space-y-2">
+        {docs.map(doc => (
+          <li key={doc.document_id} className="border p-2 rounded space-y-1">
+            <div className="flex justify-between items-center">
+              <div>
+                <Link
+                  href={`/docs/${doc.document_id}`}
+                  className="text-blue-600 underline font-semibold"
+                >
+                  {doc.file_name}
+                </Link>
+                {doc.summary && (
+                  <p className="text-sm text-gray-500">{doc.summary}</p>
+                )}
+                <p className="text-xs text-gray-600">
+                  {new Date(doc.upload_time).toLocaleString()} | ID: {doc.document_id}
+                </p>
+              </div>
+              <div className="space-x-2 whitespace-nowrap">
+                <button
+                  type="button"
+                  onClick={() => setSelectedDocId(doc.document_id)}
+                  className="px-2 py-1 text-sm bg-green-500 text-white rounded"
+                >
+                  選擇
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(doc.document_id)}
+                  className="px-2 py-1 text-sm bg-red-600 text-white rounded"
+                >
+                  刪除
+                </button>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,6 +1,11 @@
 import '@/styles/globals.css'
 import type { AppProps } from 'next/app'
+import { DocProvider } from '@/components/DocContext'
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <DocProvider>
+      <Component {...pageProps} />
+    </DocProvider>
+  )
 }

--- a/frontend/pages/docs/[id].tsx
+++ b/frontend/pages/docs/[id].tsx
@@ -1,0 +1,20 @@
+import { useRouter } from 'next/router'
+import DocumentDetail from '@/components/DocumentDetail'
+import Link from 'next/link'
+
+export default function DocPage() {
+  const router = useRouter()
+  const { id } = router.query
+
+  if (!id || Array.isArray(id)) return null
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <Link href="/" className="text-blue-600 underline">
+        返回
+      </Link>
+      <h1 className="text-2xl font-bold">Document {id}</h1>
+      <DocumentDetail id={id} />
+    </div>
+  )
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,70 +1,13 @@
 import UploadForm from '@/components/UploadForm'
 import QnAForm from '@/components/QnAForm'
-import { useEffect, useState } from 'react'
-import { fetchDocs, fetchDocumentSegments } from '@/utils/api'
-
-interface Doc {
-  document_id: string
-  file_name: string
-  upload_time: string
-  summary?: string
-}
-
-interface Segment {
-  text: string
-  chunk_index?: number
-}
+import DocumentsList from '@/components/DocumentsList'
 
 export default function Home() {
-  const [docs, setDocs] = useState<Doc[]>([])
-  const [segments, setSegments] = useState<Segment[]>([])
-  const [selected, setSelected] = useState<string | null>(null)
-
-  useEffect(() => {
-    fetchDocs().then(data => setDocs(data.documents || []))
-  }, [])
-
-  async function handleSelect(id: string) {
-    const data = await fetchDocumentSegments(id)
-    setSelected(id)
-    setSegments(data.segments || [])
-  }
-
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-8">
       <h1 className="text-2xl font-bold text-center">Document Q&A</h1>
       <UploadForm />
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold">檔案紀錄</h2>
-        <ul className="list-disc list-inside space-y-2">
-          {docs.map(doc => (
-            <li key={doc.document_id} className="space-y-0.5">
-              <button
-                className="text-blue-600 underline font-semibold"
-                onClick={() => handleSelect(doc.document_id)}
-              >
-                {doc.file_name}
-              </button>
-              {doc.summary && (
-                <p className="text-sm text-gray-500">{doc.summary}</p>
-              )}
-              <p className="text-xs text-gray-600">
-                {new Date(doc.upload_time).toLocaleString()} | ID: {doc.document_id}
-              </p>
-            </li>
-          ))}
-        </ul>
-        {selected && (
-          <div className="space-y-1 mt-2">
-            <h3 className="font-semibold">Segments of {selected}</h3>
-            <ul className="list-decimal list-inside space-y-1">
-              {segments.map((s, idx) => (
-                <li key={idx}>{s.text}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </div>
+      <DocumentsList />
       <QnAForm />
     </div>
   )

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -12,13 +12,15 @@ export async function uploadFile(file: File) {
   return res.json();
 }
 
-export async function askQuestion(question: string) {
+export async function askQuestion(question: string, documentId?: string) {
+  const body: Record<string, unknown> = { question }
+  if (documentId) body.document_id = documentId
   const res = await fetch('/api/ask', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ question }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) {
     throw new Error('Request failed');
@@ -36,6 +38,20 @@ export async function fetchDocs() {
 
 export async function fetchDocumentSegments(id: string) {
   const res = await fetch(`/api/docs/${id}`);
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return res.json();
+}
+
+export async function deleteDoc(id: string) {
+  const res = await fetch('/api/docs', {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ document_id: id }),
+  });
   if (!res.ok) {
     throw new Error('Request failed');
   }


### PR DESCRIPTION
## Summary
- enable limiting questions by document and deleting documents
- store document summaries in index and support removal
- expose document selection context to frontend
- add Components for listing and viewing documents
- persist Q&A history in localStorage and allow requery

## Testing
- `python -m py_compile app/main.py app/upload.py app/services/qdrant_client.py`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8cf39ab48333a32b75fb30aa032e