### PR TITLE
Implement tags, resummarize and UI enhancements

### DIFF
--- a/app/upload.py
+++ b/app/upload.py
@@ -46,12 +46,14 @@ def save_doc_index(index: dict) -> None:
     with open(DOC_INDEX_FILE, "w", encoding="utf-8") as f:
         json.dump(index, f, ensure_ascii=False, indent=2)
 
-def append_doc_summary(document_id: str, summary: str) -> None:
+def append_doc_entry(document_id: str, summary: str, tags: list[str]) -> None:
+    """Add or update document entry with summary and tags"""
     index = load_doc_index()
-    index[document_id] = summary
+    index[document_id] = {"summary": summary, "tags": tags}
     save_doc_index(index)
 
-def remove_doc_summary(document_id: str) -> None:
+def remove_doc_entry(document_id: str) -> None:
+    """Remove document entry from index"""
     index = load_doc_index()
     if document_id in index:
         index.pop(document_id, None)
@@ -72,7 +74,7 @@ def get_embedding(text: str) -> List[float]:
         logger.exception("Embedding service error: %s", exc)
         raise HTTPException(status_code=500, detail=f"Embedding service error: {exc}") from exc
 
-def upload_document(document_id: str, chunks: List[str], file_name: str) -> str:
+def upload_document(document_id: str, chunks: List[str], file_name: str, tags: list[str]) -> str:
     points = []
     upload_time = datetime.utcnow().isoformat()
     for idx, chunk in enumerate(chunks):
@@ -102,5 +104,5 @@ def upload_document(document_id: str, chunks: List[str], file_name: str) -> str:
     except Exception as exc:
         logger.exception("Ollama summary error: %s", exc)
         raise HTTPException(status_code=500, detail=f"Ollama service error: {exc}") from exc
-    append_doc_summary(document_id, summary)
+    append_doc_entry(document_id, summary, tags)
     return summary

--- a/frontend/components/UploadForm.tsx
+++ b/frontend/components/UploadForm.tsx
@@ -4,14 +4,16 @@ import { uploadFile } from '@/utils/api'
 export default function UploadForm() {
   const [file, setFile] = useState<File | null>(null)
   const [message, setMessage] = useState('')
+  const [tags, setTags] = useState('')
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!file) return
     try {
-      await uploadFile(file)
+      await uploadFile(file, tags)
       setMessage('Upload succeeded')
       setFile(null)
+      setTags('')
     } catch (err) {
       setMessage('Upload failed')
     }
@@ -24,6 +26,13 @@ export default function UploadForm() {
         accept="application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         onChange={e => setFile(e.target.files?.[0] || null)}
         className="block w-full text-sm"
+      />
+      <input
+        type="text"
+        value={tags}
+        onChange={e => setTags(e.target.value)}
+        placeholder="tags (comma separated)"
+        className="block w-full border rounded p-2 text-sm"
       />
       <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
         Upload

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -1,6 +1,7 @@
-export async function uploadFile(file: File) {
+export async function uploadFile(file: File, tags: string) {
   const formData = new FormData();
   formData.append('file', file);
+  formData.append('tags', tags);
 
   const res = await fetch('/api/upload', {
     method: 'POST',
@@ -52,6 +53,14 @@ export async function deleteDoc(id: string) {
     },
     body: JSON.stringify({ document_id: id }),
   });
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return res.json();
+}
+
+export async function resummarizeDoc(id: string) {
+  const res = await fetch(`/api/docs/${id}/resummarize`, { method: 'POST' });
   if (!res.ok) {
     throw new Error('Request failed');
   }


### PR DESCRIPTION
## Summary
- support tags in document uploads and listing
- include chunk index & score in `/api/ask`
- allow document resummarization via `/api/docs/{document_id}/resummarize`
- add tag filtering and resummarize button in document list
- show loading spinner and typewriter animation for answers

## Testing
- `python -m py_compile app/main.py app/upload.py`
- `npx -y tsc -p frontend/tsconfig.json --noEmit` *(fails: Non-relative paths are not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_685de737b8ac8333a14a0bc4da9bb6cb