### PR TITLE
Add customizable prompt, caching, multi-doc support

### DIFF
--- a/app/services/qdrant_client.py
+++ b/app/services/qdrant_client.py
@@ -44,11 +44,23 @@ class QdrantClient:
             logger.exception("Upload points error: %s", exc)
             raise HTTPException(status_code=500, detail=f"Qdrant error: {exc}") from exc
 
-    def search(self, vector: List[float], limit: int = 3, document_id: Optional[str] = None) -> List[Dict]:
-        """根據向量進行相似度搜尋，可依 document_id 篩選"""
+    def search(
+        self,
+        vector: List[float],
+        limit: int = 3,
+        document_id: Optional[str] = None,
+        document_ids: Optional[List[str]] = None,
+    ) -> List[Dict]:
+        """根據向量進行相似度搜尋，可依 document_id 或多個 document_ids 篩選"""
         try:
             body: Dict = {"vector": vector, "limit": limit}
-            if document_id:
+            if document_ids:
+                body["filter"] = {
+                    "must": [
+                        {"key": "document_id", "match": {"any": document_ids}}
+                    ]
+                }
+            elif document_id:
                 body["filter"] = {
                     "must": [{"key": "document_id", "match": {"value": document_id}}]
                 }

--- a/frontend/components/DocContext.tsx
+++ b/frontend/components/DocContext.tsx
@@ -1,13 +1,13 @@
 import { createContext, useContext, useState } from 'react'
 
 interface DocState {
-  selectedDocId: string | null
-  setSelectedDocId: (id: string | null) => void
+  selectedDocIds: string[]
+  setSelectedDocIds: (ids: string[]) => void
 }
 
 const DocContext = createContext<DocState>({
-  selectedDocId: null,
-  setSelectedDocId: () => {},
+  selectedDocIds: [],
+  setSelectedDocIds: () => {},
 })
 
 export function useDoc() {
@@ -15,9 +15,9 @@ export function useDoc() {
 }
 
 export function DocProvider({ children }: { children: React.ReactNode }) {
-  const [selectedDocId, setSelectedDocId] = useState<string | null>(null)
+  const [selectedDocIds, setSelectedDocIds] = useState<string[]>([])
   return (
-    <DocContext.Provider value={{ selectedDocId, setSelectedDocId }}>
+    <DocContext.Provider value={{ selectedDocIds, setSelectedDocIds }}>
       {children}
     </DocContext.Provider>
   )

--- a/frontend/components/DocumentsList.tsx
+++ b/frontend/components/DocumentsList.tsx
@@ -14,7 +14,7 @@ interface Doc {
 export default function DocumentsList() {
   const [docs, setDocs] = useState<Doc[]>([])
   const [filterTag, setFilterTag] = useState('')
-  const { selectedDocId, setSelectedDocId } = useDoc()
+  const { selectedDocIds, setSelectedDocIds } = useDoc()
 
   useEffect(() => {
     fetchDocs().then(data => setDocs(data.documents || []))
@@ -24,8 +24,8 @@ export default function DocumentsList() {
     if (!confirm('Delete document?')) return
     await deleteDoc(id)
     setDocs(docs.filter(d => d.document_id !== id))
-    if (selectedDocId === id) {
-      setSelectedDocId(null)
+    if (selectedDocIds.includes(id)) {
+      setSelectedDocIds(selectedDocIds.filter(d => d !== id))
     }
   }
 
@@ -73,13 +73,21 @@ export default function DocumentsList() {
                 </p>
               </div>
               <div className="space-x-2 whitespace-nowrap">
-                <button
-                  type="button"
-                  onClick={() => setSelectedDocId(doc.document_id)}
-                  className="px-2 py-1 text-sm bg-green-500 text-white rounded"
-                >
+                <label className="px-2 py-1 text-sm bg-green-500 text-white rounded cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="mr-1"
+                    checked={selectedDocIds.includes(doc.document_id)}
+                    onChange={() => {
+                      if (selectedDocIds.includes(doc.document_id)) {
+                        setSelectedDocIds(selectedDocIds.filter(d => d !== doc.document_id))
+                      } else {
+                        setSelectedDocIds([...selectedDocIds, doc.document_id])
+                      }
+                    }}
+                  />
                   選擇
-                </button>
+                </label>
                 <button
                   type="button"
                   onClick={() => handleDelete(doc.document_id)}

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -13,9 +13,10 @@ export async function uploadFile(file: File, tags: string) {
   return res.json();
 }
 
-export async function askQuestion(question: string, documentId?: string) {
+export async function askQuestion(question: string, documentIds: string[] = [], style?: string) {
   const body: Record<string, unknown> = { question }
-  if (documentId) body.document_id = documentId
+  if (documentIds.length > 0) body.document_ids = documentIds
+  if (style) body.style = style
   const res = await fetch('/api/ask', {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Summary
- add context token limit and caching to `/api/ask`
- support custom prompt and style in AskRequest
- allow asking across multiple documents
- show reference scores with color cues
- select multiple documents with checkboxes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685def616e508333a57002d53af95b18