### PR TITLE
Implement LLM and cosine rerank options

### DIFF
--- a/app/reranker.py
+++ b/app/reranker.py
@@ -1,0 +1,100 @@
+import json
+import logging
+import os
+from datetime import datetime
+from typing import List, Dict
+import re
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434").rstrip("/")
+OLLAMA_EMBEDDING_URL = f"{OLLAMA_BASE_URL}/api/embeddings"
+OLLAMA_GENERATE_URL = f"{OLLAMA_BASE_URL}/api/generate"
+OLLAMA_LLM_MODEL = os.getenv("LLM_MODEL", "llama2")
+OLLAMA_MODEL = os.getenv("EMBEDDING_MODEL", "nomic-embed-text")
+
+
+def get_embedding(text: str) -> List[float]:
+    """Get embedding vector from Ollama"""
+    resp = requests.post(
+        OLLAMA_EMBEDDING_URL,
+        json={"model": OLLAMA_MODEL, "prompt": text},
+    )
+    resp.raise_for_status()
+    emb = resp.json().get("embedding")
+    if emb is None:
+        raise ValueError("No embedding returned")
+    return emb
+
+
+def cosine_similarity(a: List[float], b: List[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = sum(x * x for x in a) ** 0.5
+    norm_b = sum(x * x for x in b) ** 0.5
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def rerank_passages_by_cosine(passages: List[Dict]) -> List[Dict]:
+    """Sort passages by similarity score descending"""
+    ranked = sorted(passages, key=lambda r: r.get("score", 0), reverse=True)
+    for idx, p in enumerate(ranked, 1):
+        p["rank"] = idx
+    return ranked
+
+
+def rerank_passages_with_llm(question: str, passages: List[Dict], log_path: str | None = "logs/rerank_log.jsonl") -> List[Dict]:
+    """Use LLM to rank passages"""
+    prompt_lines = [
+        "請根據問題對以下段落按相關度由高到低排序，僅回傳段落編號，以逗號分隔。",
+        f"問題: {question}",
+    ]
+    for i, p in enumerate(passages, 1):
+        text = p.get("payload", {}).get("text", "")
+        prompt_lines.append(f"({i}) {text}")
+    prompt = "\n".join(prompt_lines)
+    resp = requests.post(
+        OLLAMA_GENERATE_URL,
+        json={"model": OLLAMA_LLM_MODEL, "prompt": prompt},
+    )
+    resp.raise_for_status()
+    answer = resp.json().get("response", "")
+    numbers = [int(n) for n in re.findall(r"\d+", answer)]
+    order = [n - 1 for n in numbers if 0 < n <= len(passages)]
+    ranked = [passages[i] for i in order]
+    others = [p for i, p in enumerate(passages) if i not in order]
+    ranked.extend(others)
+    for idx, p in enumerate(ranked, 1):
+        p["rank"] = idx
+    if log_path:
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        before = [p.get("id") for p in passages]
+        after = [p.get("id") for p in ranked]
+        with open(log_path, "a", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "question": question,
+                    "before": before,
+                    "after": after,
+                },
+                f,
+                ensure_ascii=False,
+            )
+            f.write("\n")
+    return ranked
+
+
+
+def rerank_passages(question: str, passages: List[Dict], mode: str = "llm") -> List[Dict]:
+    """Entry point for passage reranking"""
+    if mode == "cosine":
+        return rerank_passages_by_cosine(passages)
+    return rerank_passages_with_llm(question, passages)
+

--- a/frontend/components/QnAForm.tsx
+++ b/frontend/components/QnAForm.tsx
@@ -6,6 +6,8 @@ interface Reference {
   text: string
   chunk_index?: number
   score?: number
+  rank?: number
+  filtered?: boolean
 }
 
 interface Answer {
@@ -34,6 +36,24 @@ export default function QnAForm() {
     if (score >= 0.8) return 'text-green-600'
     if (score >= 0.5) return 'text-yellow-600'
     return 'text-red-600'
+  }
+
+  function relevanceTag(ref: Reference) {
+    if (ref.rank !== undefined) {
+      return (
+        <span className="ml-1 px-1 text-xs bg-purple-200 text-purple-800 rounded">
+          Top {ref.rank}
+        </span>
+      )
+    }
+    if (ref.score !== undefined) {
+      return (
+        <span className="ml-1 px-1 text-xs bg-gray-200 text-gray-800 rounded">
+          {ref.score.toFixed(2)}
+        </span>
+      )
+    }
+    return null
   }
 
   function animateAnswer(text: string) {
@@ -151,7 +171,11 @@ export default function QnAForm() {
               <ul className="list-disc list-inside space-y-1">
                 {response.references.map((ref, idx) => (
                   <li key={idx} className={scoreColor(ref.score)}>
-                    [{ref.chunk_index}] (score: {ref.score?.toFixed(2)}) {ref.text}
+                    [{ref.chunk_index}] {ref.text}
+                    {relevanceTag(ref)}
+                    {ref.filtered && (
+                      <span className="ml-1 text-xs text-red-500">filtered</span>
+                    )}
                   </li>
                 ))}
               </ul>
@@ -189,7 +213,11 @@ export default function QnAForm() {
                   <ul className="list-disc list-inside text-sm mt-1 space-y-0.5">
                     {h.references.map((ref, rIdx) => (
                       <li key={rIdx} className={scoreColor(ref.score)}>
-                        [{ref.chunk_index}] (score: {ref.score?.toFixed(2)}) {ref.text}
+                        [{ref.chunk_index}] {ref.text}
+                        {relevanceTag(ref)}
+                        {ref.filtered && (
+                          <span className="ml-1 text-xs text-red-500">filtered</span>
+                        )}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
- add new reranker module with LLM and cosine strategies
- log LLM ranking results
- expose `/api/rank_test` for ranking experimentation
- extend ask API to use selectable rerank mode and filter low results
- display rank or score on the UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npx -y tsc -p frontend/tsconfig.json --noEmit` *(fails: Non-relative paths are not allowed when 'baseUrl' is not set)*

------
https://chatgpt.com/codex/tasks/task_e_685df20dd3108333836409a54eac8d16