### PR TITLE
Implement history logging and manual context

### DIFF
--- a/frontend/components/QnAForm.tsx
+++ b/frontend/components/QnAForm.tsx
@@ -13,6 +13,7 @@ interface Reference {
 interface Answer {
   answer: string
   references: Reference[]
+  elapsed?: number
 }
 
 interface QARecord {
@@ -20,6 +21,7 @@ interface QARecord {
   answer: string
   references: Reference[]
   documentIds?: string[]
+  elapsed?: number
 }
 
 export default function QnAForm() {
@@ -29,6 +31,7 @@ export default function QnAForm() {
   const [loading, setLoading] = useState(false)
   const [history, setHistory] = useState<QARecord[]>([])
   const [style, setStyle] = useState('')
+  const [elapsed, setElapsed] = useState(0)
   const { selectedDocIds } = useDoc()
 
   function scoreColor(score?: number) {
@@ -86,9 +89,10 @@ export default function QnAForm() {
     try {
       const data = await askQuestion(question, selectedDocIds, style)
       setResponse(data)
+      setElapsed(data.elapsed || 0)
       animateAnswer(data.answer)
       setHistory([
-        { question, answer: data.answer, references: data.references, documentIds: selectedDocIds },
+        { question, answer: data.answer, references: data.references, documentIds: selectedDocIds, elapsed: data.elapsed },
         ...history,
       ])
     } catch (err) {
@@ -110,9 +114,10 @@ export default function QnAForm() {
     try {
       const data = await askQuestion(q, docIds || [], style)
       setResponse(data)
+      setElapsed(data.elapsed || 0)
       animateAnswer(data.answer)
       setHistory([
-        { question: q, answer: data.answer, references: data.references, documentIds: docIds },
+        { question: q, answer: data.answer, references: data.references, documentIds: docIds, elapsed: data.elapsed },
         ...history,
       ])
     } catch {
@@ -132,13 +137,17 @@ export default function QnAForm() {
           className="flex-1 border rounded p-2"
           placeholder="Ask a question"
         />
-        <input
-          type="text"
+        <select
           value={style}
           onChange={e => setStyle(e.target.value)}
-          className="flex-1 border rounded p-2"
-          placeholder="Style (optional)"
-        />
+          className="border rounded p-2"
+        >
+          <option value="">預設</option>
+          <option value="專業">專業</option>
+          <option value="口語">口語</option>
+          <option value="摘要">摘要</option>
+          <option value="條列式">條列式</option>
+        </select>
         <button
           type="submit"
           className="px-4 py-2 bg-green-600 text-white rounded"
@@ -164,6 +173,7 @@ export default function QnAForm() {
               複製回答
             </button>
           </div>
+          <p className="text-sm text-gray-600">Time: {elapsed.toFixed(2)}s</p>
           <p>{displayedAnswer}</p>
           {response.references.length > 0 && (
             <div>
@@ -208,6 +218,9 @@ export default function QnAForm() {
                     </button>
                   </div>
                 </div>
+                {h.elapsed !== undefined && (
+                  <p className="text-xs text-gray-600">Time: {h.elapsed.toFixed(2)}s</p>
+                )}
                 <p className="text-sm">A: {h.answer}</p>
                 {h.references.length > 0 && (
                   <ul className="list-disc list-inside text-sm mt-1 space-y-0.5">

--- a/frontend/pages/AnswerHistory.tsx
+++ b/frontend/pages/AnswerHistory.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { fetchAskLog, askQuestion } from '@/utils/api'
+import { useDoc } from '@/components/DocContext'
+
+interface LogEntry {
+  timestamp: string
+  question: string
+  answer: string
+  document_ids?: string[]
+  rerank_mode?: string
+  style?: string
+  references: { text: string }[]
+}
+
+export default function AnswerHistory() {
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  const [filter, setFilter] = useState('')
+  const { setSelectedDocIds } = useDoc()
+
+  useEffect(() => {
+    fetchAskLog().then(data => setLogs(data.logs || []))
+  }, [])
+
+  const filtered = logs.filter(l =>
+    l.question.toLowerCase().includes(filter.toLowerCase())
+  )
+
+  async function handleReask(entry: LogEntry) {
+    setSelectedDocIds(entry.document_ids || [])
+    try {
+      const res = await askQuestion(entry.question, entry.document_ids || [], entry.style)
+      alert(res.answer)
+    } catch {
+      alert('Error')
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <Link href="/" className="text-blue-600 underline">
+        返回
+      </Link>
+      <h1 className="text-2xl font-bold">回答歷史</h1>
+      <input
+        type="text"
+        value={filter}
+        onChange={e => setFilter(e.target.value)}
+        placeholder="Filter"
+        className="border p-2 rounded w-full"
+      />
+      <ul className="space-y-2">
+        {filtered.map((log, idx) => (
+          <li key={idx} className="border p-2 rounded space-y-1">
+            <p className="text-xs text-gray-600">
+              {new Date(log.timestamp).toLocaleString()} | rerank: {log.rerank_mode}
+            </p>
+            <p className="font-semibold">Q: {log.question}</p>
+            <p>A: {log.answer}</p>
+            <button
+              type="button"
+              onClick={() => handleReask(log)}
+              className="text-sm text-green-700 underline"
+            >
+              重新查詢
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -6,6 +6,10 @@ export default function Home() {
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-8">
       <h1 className="text-2xl font-bold text-center">Document Q&A</h1>
+      <div className="flex space-x-4 justify-center text-sm">
+        <a href="/AnswerHistory" className="text-blue-600 underline">回答歷史</a>
+        <a href="/manual-context" className="text-blue-600 underline">自選段落模式</a>
+      </div>
       <UploadForm />
       <DocumentsList />
       <QnAForm />

--- a/frontend/pages/manual-context.tsx
+++ b/frontend/pages/manual-context.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import {
+  fetchDocs,
+  fetchDocumentSegments,
+  manualAsk,
+} from '@/utils/api'
+
+interface Doc {
+  document_id: string
+  file_name: string
+}
+
+interface Segment {
+  text: string
+  chunk_index?: number
+}
+
+export default function ManualContext() {
+  const [docs, setDocs] = useState<Doc[]>([])
+  const [segments, setSegments] = useState<Record<string, Segment[]>>({})
+  const [showDoc, setShowDoc] = useState<Record<string, boolean>>({})
+  const [selected, setSelected] = useState<string[]>([])
+  const [question, setQuestion] = useState('')
+  const [style, setStyle] = useState('')
+  const [answer, setAnswer] = useState('')
+  const [elapsed, setElapsed] = useState(0)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    fetchDocs().then(data => setDocs(data.documents || []))
+  }, [])
+
+  async function toggleDoc(id: string) {
+    if (!showDoc[id]) {
+      const res = await fetchDocumentSegments(id)
+      setSegments(prev => ({ ...prev, [id]: res.segments || [] }))
+    }
+    setShowDoc(prev => ({ ...prev, [id]: !prev[id] }))
+  }
+
+  function toggleSeg(text: string) {
+    if (selected.includes(text)) {
+      setSelected(selected.filter(t => t !== text))
+    } else {
+      setSelected([...selected, text])
+    }
+  }
+
+  async function handleAsk() {
+    if (!question || selected.length === 0) return
+    setLoading(true)
+    try {
+      const res = await manualAsk(question, selected, style)
+      setAnswer(res.answer)
+      setElapsed(res.elapsed || 0)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      <Link href="/" className="text-blue-600 underline">
+        返回
+      </Link>
+      <h1 className="text-2xl font-bold">自選段落模式</h1>
+      <div className="space-y-2">
+        {docs.map(doc => (
+          <div key={doc.document_id} className="border p-2 rounded">
+            <button
+              type="button"
+              onClick={() => toggleDoc(doc.document_id)}
+              className="text-blue-600 underline"
+            >
+              {showDoc[doc.document_id] ? '隱藏' : '顯示'} {doc.file_name}
+            </button>
+            {showDoc[doc.document_id] && segments[doc.document_id] && (
+              <ul className="space-y-1 mt-1">
+                {segments[doc.document_id].map((s, idx) => (
+                  <li key={idx}>
+                    <label>
+                      <input
+                        type="checkbox"
+                        className="mr-1"
+                        checked={selected.includes(s.text)}
+                        onChange={() => toggleSeg(s.text)}
+                      />
+                      [{s.chunk_index}] {s.text}
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))}
+      </div>
+      <form onSubmit={e => { e.preventDefault(); handleAsk() }} className="space-y-2">
+        <input
+          type="text"
+          value={question}
+          onChange={e => setQuestion(e.target.value)}
+          className="w-full border p-2 rounded"
+          placeholder="Ask a question"
+        />
+        <select
+          value={style}
+          onChange={e => setStyle(e.target.value)}
+          className="border rounded p-2"
+        >
+          <option value="">預設</option>
+          <option value="專業">專業</option>
+          <option value="口語">口語</option>
+          <option value="摘要">摘要</option>
+          <option value="條列式">條列式</option>
+        </select>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-green-600 text-white rounded"
+          disabled={loading}
+        >
+          {loading ? 'Asking...' : 'Ask'}
+        </button>
+      </form>
+      {answer && (
+        <div className="space-y-2 bg-gray-100 p-4 rounded">
+          <p className="text-sm text-gray-600">Time: {elapsed.toFixed(2)}s</p>
+          <p>{answer}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/utils/api.ts
+++ b/frontend/utils/api.ts
@@ -30,6 +30,30 @@ export async function askQuestion(question: string, documentIds: string[] = [], 
   return res.json();
 }
 
+export async function manualAsk(question: string, segments: string[], style?: string) {
+  const body: Record<string, unknown> = { question, segments };
+  if (style) body.style = style;
+  const res = await fetch('/api/manual-ask', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return res.json();
+}
+
+export async function fetchAskLog() {
+  const res = await fetch('/api/ask_log');
+  if (!res.ok) {
+    throw new Error('Request failed');
+  }
+  return res.json();
+}
+
 export async function fetchDocs() {
   const res = await fetch('/api/docs');
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- log `/api/ask` requests and answers to `logs/ask_log.jsonl`
- expose log records via `/api/ask_log`
- add manual context endpoint `/api/manual-ask`
- update QnA interface with style presets and elapsed time
- add answer history and manual context pages
- expose navigation links to new pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1e1d1f988333806345b13bb36e62