### PR TITLE
Fix Next.js build path alias error

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,6 +14,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"],
       "@components/*": ["components/*"],


### PR DESCRIPTION
## Summary
- add `baseUrl` to `tsconfig.json` so path aliases resolve correctly

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2e0bf0c883338e881275d5a9ef60