### PR TITLE
Fix missing Node modules in frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - "3000:3000"
     volumes:
       - ./frontend:/app
+      - /app/node_modules
     environment:
       - NEXT_PUBLIC_API_URL=http://localhost:8000
     depends_on:


### PR DESCRIPTION
## Summary
- keep node_modules inside frontend container by adding anonymous volume

This prevents the `next` command from missing when the frontend service is started with `docker-compose`.

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2f26b2bc8333a6d7b45586d7eb07