### PR TITLE
Fix Docker build error in backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /code
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY .env ./
 COPY . ./backend
 
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- remove `.env` copy from backend Dockerfile to avoid missing file during build

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_685eb9dc4ffc8333895019d87079554f