### PR TITLE
Fix frontend API URL to avoid IPv6 connection issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://localhost:8000
+      # Use IPv4 address to prevent localhost resolving to IPv6 (::1)
+      - NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
     depends_on:
       - backend
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:18-alpine
 WORKDIR /app
-ENV NEXT_PUBLIC_API_URL=http://localhost:8000
+# Use 127.0.0.1 to avoid systems resolving 'localhost' to IPv6 (::1)
+# which would fail because the backend only listens on IPv4
+ENV NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
 COPY package*.json ./
 RUN npm install
 COPY . .


### PR DESCRIPTION
## Summary
- update `NEXT_PUBLIC_API_URL` to use IPv4 address in Dockerfile
- ensure docker-compose passes IPv4 API URL to frontend

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebeae6bf48333aab5bdb213136cca