### PR TITLE
Fix frontend connection and persist ollama models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,7 @@ cython_debug/
 .cursorindexingignore
 # Node
 frontend/node_modules/
+
+# Ollama model directory
+ollama/*
+!ollama/.gitkeep

--- a/README.md
+++ b/README.md
@@ -31,3 +31,13 @@ Accepts a PDF or DOCX file and stores the text segments in Qdrant. Each chunk is
 `POST /api/ask`
 
 Receives a question and retrieves the top 5 relevant segments from Qdrant. A `rerank` function sorts them and the top 3 are used as context for Ollama to generate an answer. The response includes the answer text and referenced segments.
+
+## Docker Compose
+
+Run the full stack with Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+The Ollama service stores downloaded models in the `ollama` directory at the project root. This folder is mounted into the container so models persist across rebuilds and are not downloaded again if they already exist.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - "3000:3000"
     environment:
       # Use IPv4 address to prevent localhost resolving to IPv6 (::1)
-      - NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
+      - NEXT_PUBLIC_API_URL=http://backend:8000
     depends_on:
       - backend
 
@@ -37,8 +37,7 @@ services:
     environment:
       - OLLAMA_MODELS=nous-hermes2:Q4_K_M
     volumes:
-      - ollama_data:/root/.ollama
+      - ./ollama:/root/.ollama
 
 volumes:
   qdrant_data:
-  ollama_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:18-alpine
 WORKDIR /app
-# Use 127.0.0.1 to avoid systems resolving 'localhost' to IPv6 (::1)
-# which would fail because the backend only listens on IPv4
-ENV NEXT_PUBLIC_API_URL=http://127.0.0.1:8000
+# Use the backend service name so the frontend container can reach it
+ENV NEXT_PUBLIC_API_URL=http://backend:8000
 COPY package*.json ./
 RUN npm install
 COPY . .


### PR DESCRIPTION
## Summary
- let the frontend talk to the backend service name
- store Ollama models in `./ollama`
- ignore Ollama data in Git
- document Docker Compose usage

## Testing
- `bash test_api.sh sample.pdf` *(fails: couldn't connect to localhost port 8000)*

------
https://chatgpt.com/codex/tasks/task_e_685ec0fe1f0c8333b0d0c3ff0a840a0f